### PR TITLE
ci: fix version `format()` in Github Action

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Here are the Github Action properties:
 ```yaml
 inputs:
   version:
-    description: "Version of go-ci-fuzz, e.g. latest or 0.1.0"
+    description: "Version of go-ci-fuzz, e.g. latest or 0.1.1"
     required: false
-    default: "0.1.0"
+    default: "0.1.1"
   source-path:
     description: "Path to the project's source code, current directory by default."
     required: false
@@ -94,7 +94,7 @@ jobs:
         go-version: stable
     - name: Run fuzzers
       id: build
-      uses: form3tech-oss/go-ci-fuzz/ci/github-actions/fuzz@v0.1.0
+      uses: form3tech-oss/go-ci-fuzz/ci/github-actions/fuzz@v0.1.1
       with:
         fuzz-time: 5m
         fail-fast: true
@@ -123,7 +123,7 @@ jobs:
         go-version: stable
     - name: Run fuzzers
       id: build
-      uses: form3tech-oss/go-ci-fuzz/ci/github-actions/fuzz@v0.1.0
+      uses: form3tech-oss/go-ci-fuzz/ci/github-actions/fuzz@v0.1.1
       with:
         fuzz-time: 30m
         fail-fast: false

--- a/ci/github-actions/fuzz/action.yml
+++ b/ci/github-actions/fuzz/action.yml
@@ -67,7 +67,7 @@ runs:
       uses: dsaltares/fetch-gh-release-asset@3942ce82f1192754cd487a86f03eef6eeb89b5da # 1.1.0
       with:
         repo: 'form3tech-oss/go-ci-fuzz'
-        version: ${{ inputs.version == 'latest' && 'latest' || format('tags/v%s', inputs.version) }}
+        version: ${{ inputs.version == 'latest' && 'latest' || format('tags/v{0}', inputs.version) }}
         file: ${{ steps.archive-info.outputs.ARCHIVE_PATH }}
     - id: extract
       name: Extract go-ci-fuzz

--- a/ci/github-actions/fuzz/action.yml
+++ b/ci/github-actions/fuzz/action.yml
@@ -2,9 +2,9 @@ name: "fuzz"
 description: "Runs fuzzing targets using go-ci-fuzz"
 inputs:
   version:
-    description: "Version of go-ci-fuzz, e.g. latest or 0.1.0"
+    description: "Version of go-ci-fuzz, e.g. latest or 0.1.1"
     required: false
-    default: "0.1.0"
+    default: "0.1.1"
   source-path:
     description: "Path to the project's source code, current directory by default."
     required: false


### PR DESCRIPTION
Before:
![image](https://github.com/form3tech-oss/go-ci-fuzz/assets/91873652/734885c3-3fdc-41e0-8f94-90a58145081a)

After:
![image](https://github.com/form3tech-oss/go-ci-fuzz/assets/91873652/76bb0a7b-578d-465c-aa61-363da57d5008)
