### PR TITLE
fix: use sha versioning for upload-artifact

### DIFF
--- a/ci/github-actions/fuzz/action.yml
+++ b/ci/github-actions/fuzz/action.yml
@@ -87,7 +87,7 @@ runs:
         mkdir -p $TEMP_DIR
         echo "FAILING_INPUTS_DIR=${TEMP_DIR}" >> "$GITHUB_OUTPUT"
         ${RUNNER_TEMP}/${{ steps.archive-info.outputs.EXE_NAME }} fuzz ./... --fuzz-time "${{ inputs.fuzz-time }}" --fail-fast="${{ inputs.fail-fast }}" --out="${TEMP_DIR}/"
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
       if: 'failure()'
       with:
         name: ${{ inputs.artifact-name }}

--- a/ci/github-actions/fuzz/action.yml
+++ b/ci/github-actions/fuzz/action.yml
@@ -87,7 +87,7 @@ runs:
         mkdir -p $TEMP_DIR
         echo "FAILING_INPUTS_DIR=${TEMP_DIR}" >> "$GITHUB_OUTPUT"
         ${RUNNER_TEMP}/${{ steps.archive-info.outputs.EXE_NAME }} fuzz ./... --fuzz-time "${{ inputs.fuzz-time }}" --fail-fast="${{ inputs.fail-fast }}" --out="${TEMP_DIR}/"
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
       if: 'failure()'
       with:
         name: ${{ inputs.artifact-name }}


### PR DESCRIPTION
Hi,

This GHA uses non-sha versioning for one of GHAs it is using internally which fails our build in one of the internal projects

<img width="1369" alt="Screenshot 2024-03-01 at 14 39 09" src="https://github.com/form3tech-oss/go-ci-fuzz/assets/122449408/b8a1f17c-ae1b-426e-9db0-c633330a4e60">

This PR fixes that by pinning the `upload-artifact` to the latest v3 commit