### PR TITLE
chore: updated docs after recent release 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Here are the Github Action properties:
 ```yaml
 inputs:
   version:
-    description: "Version of go-ci-fuzz, e.g. latest or 0.1.1"
+    description: "Version of go-ci-fuzz, e.g. latest or 0.1.2"
     required: false
-    default: "0.1.1"
+    default: "0.1.2"
   source-path:
     description: "Path to the project's source code, current directory by default."
     required: false
@@ -94,7 +94,7 @@ jobs:
         go-version: stable
     - name: Run fuzzers
       id: build
-      uses: form3tech-oss/go-ci-fuzz/ci/github-actions/fuzz@v0.1.1
+      uses: form3tech-oss/go-ci-fuzz/ci/github-actions/fuzz@196db179c18454423086c68c1e8a2645593e348d # v0.1.2
       with:
         fuzz-time: 5m
         fail-fast: true
@@ -123,7 +123,7 @@ jobs:
         go-version: stable
     - name: Run fuzzers
       id: build
-      uses: form3tech-oss/go-ci-fuzz/ci/github-actions/fuzz@v0.1.1
+      uses: form3tech-oss/go-ci-fuzz/ci/github-actions/fuzz@196db179c18454423086c68c1e8a2645593e348d # v0.1.2
       with:
         fuzz-time: 30m
         fail-fast: false

--- a/ci/github-actions/fuzz/action.yml
+++ b/ci/github-actions/fuzz/action.yml
@@ -2,9 +2,9 @@ name: "fuzz"
 description: "Runs fuzzing targets using go-ci-fuzz"
 inputs:
   version:
-    description: "Version of go-ci-fuzz, e.g. latest or 0.1.1"
+    description: "Version of go-ci-fuzz, e.g. latest or 0.1.2"
     required: false
-    default: "0.1.1"
+    default: "0.1.2"
   source-path:
     description: "Path to the project's source code, current directory by default."
     required: false


### PR DESCRIPTION
I made manual release of 0.1.2 after PR #4
Current PR updates the docs accordingly