### PR TITLE
Updates upload-artifact to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,9 @@ Here are the Github Action properties:
 ```yaml
 inputs:
   version:
-    description: "Version of go-ci-fuzz, e.g. latest or 0.1.2"
+    description: "Version of go-ci-fuzz, e.g. latest or 0.1.3"
     required: false
-    default: "0.1.2"
+    default: "0.1.3"
   source-path:
     description: "Path to the project's source code, current directory by default."
     required: false

--- a/ci/github-actions/fuzz/action.yml
+++ b/ci/github-actions/fuzz/action.yml
@@ -87,7 +87,7 @@ runs:
         mkdir -p $TEMP_DIR
         echo "FAILING_INPUTS_DIR=${TEMP_DIR}" >> "$GITHUB_OUTPUT"
         ${RUNNER_TEMP}/${{ steps.archive-info.outputs.EXE_NAME }} fuzz ./... --fuzz-time "${{ inputs.fuzz-time }}" --fail-fast="${{ inputs.fail-fast }}" --out="${TEMP_DIR}/"
-    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392" # v4.0.0
+    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
       if: 'failure()'
       with:
         name: ${{ inputs.artifact-name }}

--- a/ci/github-actions/fuzz/action.yml
+++ b/ci/github-actions/fuzz/action.yml
@@ -87,7 +87,7 @@ runs:
         mkdir -p $TEMP_DIR
         echo "FAILING_INPUTS_DIR=${TEMP_DIR}" >> "$GITHUB_OUTPUT"
         ${RUNNER_TEMP}/${{ steps.archive-info.outputs.EXE_NAME }} fuzz ./... --fuzz-time "${{ inputs.fuzz-time }}" --fail-fast="${{ inputs.fail-fast }}" --out="${TEMP_DIR}/"
-    - uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+    - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392" # v4.0.0
       if: 'failure()'
       with:
         name: ${{ inputs.artifact-name }}

--- a/ci/github-actions/fuzz/action.yml
+++ b/ci/github-actions/fuzz/action.yml
@@ -2,9 +2,9 @@ name: "fuzz"
 description: "Runs fuzzing targets using go-ci-fuzz"
 inputs:
   version:
-    description: "Version of go-ci-fuzz, e.g. latest or 0.1.2"
+    description: "Version of go-ci-fuzz, e.g. latest or 0.1.3"
     required: false
-    default: "0.1.2"
+    default: "0.1.3"
   source-path:
     description: "Path to the project's source code, current directory by default."
     required: false


### PR DESCRIPTION
This PR updates `upload-artifact` action to v4.
This version is allowlisted [here](https://github.com/form3tech/infrastructure-github/blob/2a0f7dd66eb30d9d58631034408118c944c46d9d/tf/teams/locals.tf#L177)