### PR TITLE
fix: fix 403 when downloading go-ci-fuzz releases

### DIFF
--- a/.github/workflows/test-github-action.yml
+++ b/.github/workflows/test-github-action.yml
@@ -1,6 +1,6 @@
 name: test-github-action
 
-on: [push]
+on: [ push ]
 
 permissions:
   contents: read
@@ -48,3 +48,43 @@ jobs:
         # When a continue-on-error step fails, the outcome is failure, but the final conclusion is success.
         if: steps.fuzz.outcome != 'failure'
         run: exit 1
+  checksum-check:
+    strategy:
+      matrix:
+        case: [
+          {
+            checksum: "",
+            outcome: "success"
+          },
+          {
+            checksum: "7c764843d427939a61e09b1cd631412252a625c68e0e88b8d1bc110d1cfbd029",
+            outcome: "success"
+          },
+          {
+            checksum: "11111113d427939a61e09b1cd631412252a625c68e0e88b8d1bc110d1cfbd029",
+            outcome: "failure"
+          }
+        ]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
+        with:
+          go-version: stable
+      - name: Run fuzzers
+        id: fuzz
+        uses: ./ci/github-actions/fuzz
+        continue-on-error: true
+        with:
+          fuzz-time: 10s
+          fail-fast: true
+          source-path: fuzz/testdata/fuzzing/nofindings
+          version: 0.1.3
+          checksum: ${{ matrix.case.checksum }}
+      - name: Verify the outcome
+        # https://docs.github.com/en/actions/learn-github-actions/contexts#steps-context
+        # When a continue-on-error step fails, the outcome is failure, but the final conclusion is success.
+        if: ${{ steps.fuzz.outcome != matrix.case.outcome }}
+        run: |
+          echo "Test Failed - got: ${{ steps.fuzz.outcome }} != expected: ${{ matrix.case.outcome }}"
+          exit 1

--- a/.github/workflows/test-github-action.yml
+++ b/.github/workflows/test-github-action.yml
@@ -1,6 +1,6 @@
 name: test-github-action
 
-on: [ push ]
+on: [push]
 
 permissions:
   contents: read

--- a/ci/github-actions/fuzz/action.yml
+++ b/ci/github-actions/fuzz/action.yml
@@ -63,12 +63,15 @@ runs:
         echo "ARCHIVE_PATH=go-ci-fuzz_${ARCHIVE_OS}_${ARCHIVE_ARCH}.${ARCHIVE_EXT}" >> "$GITHUB_OUTPUT"
         echo "EXE_NAME=go-ci-fuzz${EXE_EXT}" >> "$GITHUB_OUTPUT"
     - id: fetch-asset
-      name: Get Release Asset
-      uses: dsaltares/fetch-gh-release-asset@3942ce82f1192754cd487a86f03eef6eeb89b5da # 1.1.0
-      with:
-        repo: 'form3tech-oss/go-ci-fuzz'
-        version: ${{ inputs.version == 'latest' && 'latest' || format('tags/v{0}', inputs.version) }}
-        file: ${{ steps.archive-info.outputs.ARCHIVE_PATH }}
+      name: Download Go Ci Fuzz release
+      shell: bash
+      run: |
+        set -euo pipefail
+        FILE_NAME=${{ steps.archive-info.outputs.ARCHIVE_PATH }}
+        REL_PATH=${{ inputs.version == 'latest' && 'latest' || format('tags/v{0}', inputs.version) }}
+        RELEASE=$(curl -H "Accept: application/vnd.github+json" "https://api.github.com/repos/form3tech-oss/go-ci-fuzz/releases/$REL_PATH")
+        DOWNLOAD_PATH=$(<<<$RELEASE jq -r --arg file_name "$FILE_NAME" '.assets[] | select (.name == $file_name) | .browser_download_url')
+        curl -L -o "$FILE_NAME" "$DOWNLOAD_PATH"
     - id: extract
       name: Extract go-ci-fuzz
       shell: bash

--- a/ci/github-actions/fuzz/action.yml
+++ b/ci/github-actions/fuzz/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "Name of the artifact"
     required: false
     default: "failing-inputs"
+  checksum:
+    description: "Checksum of go-ci-fuzz archive. If empty skips verification"
+    required: false
+    default: ""
 runs:
   using: "composite"
   steps:
@@ -72,6 +76,14 @@ runs:
         RELEASE=$(curl -H "Accept: application/vnd.github+json" "https://api.github.com/repos/form3tech-oss/go-ci-fuzz/releases/$REL_PATH")
         DOWNLOAD_PATH=$(<<<$RELEASE jq -r --arg file_name "$FILE_NAME" '.assets[] | select (.name == $file_name) | .browser_download_url')
         curl -L -o "$FILE_NAME" "$DOWNLOAD_PATH"
+        
+        if [ ! -z "${{ inputs.checksum }}" ]; then
+          echo "${{ inputs.checksum }} $FILE_NAME" | sha256sum -c
+          if [ $? != 0 ]; then
+            echo 'checksum does not match'
+            exit 1
+          fi
+        fi
     - id: extract
       name: Extract go-ci-fuzz
       shell: bash
@@ -91,7 +103,7 @@ runs:
         echo "FAILING_INPUTS_DIR=${TEMP_DIR}" >> "$GITHUB_OUTPUT"
         ${RUNNER_TEMP}/${{ steps.archive-info.outputs.EXE_NAME }} fuzz ./... --fuzz-time "${{ inputs.fuzz-time }}" --fail-fast="${{ inputs.fail-fast }}" --out="${TEMP_DIR}/"
     - uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
-      if: 'failure()'
+      if: ${{ failure() && steps.fuzz.outcome == 'failure' }}
       with:
         name: ${{ inputs.artifact-name }}
         path: ${{ steps.fuzz.outputs.FAILING_INPUTS_DIR }}/

--- a/ci/github-actions/fuzz/action.yml
+++ b/ci/github-actions/fuzz/action.yml
@@ -67,7 +67,7 @@ runs:
         echo "ARCHIVE_PATH=go-ci-fuzz_${ARCHIVE_OS}_${ARCHIVE_ARCH}.${ARCHIVE_EXT}" >> "$GITHUB_OUTPUT"
         echo "EXE_NAME=go-ci-fuzz${EXE_EXT}" >> "$GITHUB_OUTPUT"
     - id: fetch-asset
-      name: Download Go Ci Fuzz release
+      name: Download Go CI Fuzz release
       shell: bash
       run: |
         set -euo pipefail


### PR DESCRIPTION
If a GitHub token is passed to a GitHub API of a public repo it can result in 403 if the org behind it has IP filtering enabled.

`dsaltares/fetch-gh-release-asset` does not support not passing GH tokens, so this PR will switch to a more barebones approach of calling cURL directly to fetch the release.